### PR TITLE
some fix to test.py and the docker file under linux

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:latest
 RUN apt-get update && apt-get -y --no-install-recommends install \
+   python3-venv \
    python3-setuptools \
    python3-pip \
    python3-dev \
@@ -10,14 +11,17 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
    libboost-dev\
    cmake && apt-get clean
 
-RUN pip install tqdm h5py
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install tqdm h5py wheel
+
 # disable visuals as we are on docker
 ENV PCL_BENCHMARK_NOVISUALIZATION=1
 
 # The add will invalidate all subsequent steps if the latest_commit has changed. Nice!
-ADD "https://api.github.com/repos/tum-bgd/pointcloudqueries/commits?per_page=1" latest_commit 
-RUN git clone --recurse-submodules https://github.com/tum-bgd/pointcloudqueries.git
+ADD "https://api.github.com/repos/tum-bgd/pointcloudqueries/commits?per_page=1" latest_commit
+RUN git clone --recurse-submodules https://github.com/xdrl1/pointcloudqueries.git
 WORKDIR /pointcloudqueries
 RUN python3 setup.py bdist_wheel
 RUN pip install dist/*
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ ENV PCL_BENCHMARK_NOVISUALIZATION=1
 
 # The add will invalidate all subsequent steps if the latest_commit has changed. Nice!
 ADD "https://api.github.com/repos/tum-bgd/pointcloudqueries/commits?per_page=1" latest_commit
-RUN git clone --recurse-submodules https://github.com/xdrl1/pointcloudqueries.git
+RUN git clone --recurse-submodules https://github.com/tum-bgd/pointcloudqueries.git
 WORKDIR /pointcloudqueries
 RUN python3 setup.py bdist_wheel
 RUN pip install dist/*

--- a/test.py
+++ b/test.py
@@ -33,6 +33,6 @@ print(radii)
 
 # Eigenfeatures
 start = time.time()
-distancemap = x.eigenfeatures("test", 7);
+distancemap = x.eigenfeatures_knn("test", 7);
 print("Eigenfeatures: %s" %(str(time.time()-start)))
 print(x.get_attrib("test_linearity"))


### PR DESCRIPTION
For `docker/Dockerfile`:

1. Run `pip install` directly may trigger `error: externally-managed-environment` (see [PEP 668](https://peps.python.org/pep-0668)), especially for new versions of Linux distributions. Possible solutions include:

    - pass `--break-system-packages` flag. Obviously, it will affect the build-in Python in the system.
    - install a management tool, namely `Pipx`. But this software require a bunch of dependencies, which will enlarge the size of the generated docker image.
    - (current solution in this PR) use virtual env. It indeed may sound weird to use virtual env in a docker, but it seems to be the best solution.

2. `wheel` is needed. Otherwise, `error: invalid command 'bdist_wheel'` will be triggered.


For `test.py`:

`x.eigenfeatures_knn()` or `x.eigenfeatures_range()` instead of `x.eigenfeatures()`? Because there is no `eigenfeatures` defined in `src/main.cpp`.