### PR TITLE
compile on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,15 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_FLAGS "-Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
-set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -march=native -fopenmp")
+if(MSVC)
+  set(CMAKE_CXX_FLAGS "/Wall /EHsc")
+  set(CMAKE_CXX_FLAGS_DEBUG "/Zi /MTd")
+  set(CMAKE_CXX_FLAGS_RELEASE "/O2 /MT /openmp:llvm")
+else()
+  set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+  set(CMAKE_CXX_FLAGS_DEBUG "-g")
+  set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -march=native -fopenmp")
+endif()
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 find_package (Eigen3 3.3 REQUIRED NO_MODULE)
@@ -39,4 +45,4 @@ set_target_properties(pointcloudqueries PROPERTIES CXX_VISIBILITY_PRESET "hidden
 # define (VERSION_INFO) here.
 #target_compile_definitions(pointcloudqueries
 #                           PRIVATE VERSION_INFO=${EXAMPLE_VERSION_INFO})
-			   
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Point Cloud Queries
+
 A Python module for selected point cloud queries
 
 This code is for educational purposes
@@ -15,32 +16,60 @@ It is a NFDI4Earth Educational Resource, more information on https://www.bgd.ed.
 # Installation
 
 ## The plan
+
 When we have fixed the usability and add some documentation, we will build binary distributions for Linux,  Windows and Python >= 3.7 and push it to pypi,
 such that you just need to
+
 ```
-pip install pointcloudqueries # This does not yet work
+> pip install pointcloudqueries # This does not yet work
 ```
 
 ## At the moment
-### On Linux
-easy.
+
 ### On Windows
-- Install Visual Studio
-- Download Boost (boost.org) 1.82 to `c:\boost`, and unpack it and make sure that `C:\boost\boost_1_82_0\boost_1_82_0\boost\geometry" is the directory containing the Boost Geometry Library
-- If you end up with Boost somewhere else, update include_dirs in setup.py
-- Install Python (preferably from python.org, for example, `https://www.python.org/ftp/python/3.11.3/python-3.11.3-amd64.exe` and let it upgrade the py launcher.
-- Try that in a command line `py` runs python3
-- py -m pip install numpy # numpy is a dependency for our package
-- py setup.py develop
-- py test.py
+
+- Setup a C++ compilation environment
+  - Install Visual Studio, and use the VS installer to install *Desktop development with C++* module.
+  - Install [CMake](https://cmake.org/download/)
+- Install Python
+  - preferably from python.org, for example, `https://www.python.org/ftp/python/3.11.3/python-3.11.3-amd64.exe` and let it upgrade the py launcher.
+  - Try that in a command line `py` runs python3
+- Configure Eigen3 using CMake
+  - First, go to a directory as your preference, then
+    ```
+    > git clone https://gitlab.com/libeigen/eigen.git
+    > cd eigen && mkdir build && cd build && cmake ..
+    ```
+  - These steps will take care of environmental variables for Eigen compilation
+- Install dependencies for Python
+  ```
+  > py -3.X -m pip install wheel tqdm h5py scipy
+  ```
+
+  - matplotlib and open3d also needed if visualization required
+- Compile and install the `pointcloudqueries` library
+  ```
+  > py -3.X setup.py bdist_wheel
+  > py -3.X -m pip install ./dist/*.whl
+  ```
+- Run benchmark
+  ```
+  > py -3.X ./benchmark/benchmark.py
+  ```
 
 ### On Linux
-We go for manylinux with 
+
+We go for manylinux with
+
 ```
 $ docker run -it --rm  -v $PWD:/io quay.io/pypa/manylinux2014_x
 # cd io/
 # /opt/python/cp37-cp37m/bin/python setup.py bdist_wheel
 # auditwheel repair pointcloudqueries-0.0.1-cp38-cp38-linux_x86_64.whl
 ```
+
 The wheelhouse contains a manylinux-wheel
-docker run -it --rm mwernerds/pointcloudqueries python3 benchmark/benchmark.py
+
+```
+> docker run -it --rm mwernerds/pointcloudqueries python3 benchmark/benchmark.py
+```


### PR DESCRIPTION
## Updates for `CMakeLists.txt`

Add `MSVC` support when compiling on Windows machines. I tried to use comparable flags with `gcc` for `cl`, note that

- No comparable flags for `-Wextra` as far as I can see.
- `/EHsc` flag for [handling exceptions](https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170). Compilation failed (for `boost`) without it.
- `/MTd` and `/MT` for multithreading.
- `openmp:llvm` for openmp support.
- It seems that MSVC can only specify CPU arch for optimization given corresponding flags rather than automatically deciding by the compiler in `gcc`. See [here](https://learn.microsoft.com/en-us/cpp/build/reference/favor-optimize-for-architecture-specifics?view=msvc-170). For compatibility concerns, I didn't specify here.

For other flags, please refer to this [document](https://learn.microsoft.com/en-us/cpp/build/reference/compiler-options-listed-by-category?view=msvc-170).

## Updates for `README.md`

Add brief instructions for compilation on Windows machines.
